### PR TITLE
feat: upgrade zod to v4 with schema tests written first

### DIFF
--- a/lib/schemas.test.mts
+++ b/lib/schemas.test.mts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { formSchema } from "./schemas.ts";
+
+/**
+ * Characterises the validation the create API relies on. Written before the
+ * zod 3 -> 4 upgrade so the upgrade has to preserve this behaviour, including
+ * the exact user-facing messages, which surface in the form.
+ */
+function messagesFor(input: unknown): string[] {
+  const result = formSchema.safeParse(input);
+  assert.equal(result.success, false, "expected validation to fail");
+  return result.error!.issues.map((i) => i.message);
+}
+
+describe("formSchema", () => {
+  test("accepts a plain https url", () => {
+    const result = formSchema.safeParse({ url: "https://example.com" });
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, { url: "https://example.com" });
+  });
+
+  test("accepts an optional shorthand", () => {
+    const result = formSchema.safeParse({
+      url: "https://example.com",
+      shorthand: "mine",
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.data?.shorthand, "mine");
+  });
+
+  test("rejects a url that is not a url at all", () => {
+    assert.ok(messagesFor({ url: "http://" }).length > 0);
+  });
+
+  test("rejects a non-http scheme", () => {
+    assert.ok(
+      messagesFor({ url: "ftp://example.com" }).includes("URL must start with http:// or https://"),
+    );
+  });
+
+  test("rejects a url over 2000 characters", () => {
+    const long = `https://example.com/${"a".repeat(2000)}`;
+    assert.ok(messagesFor({ url: long }).includes("URL must be shorter than 2000 characters"));
+  });
+
+  test("rejects a shorthand over 30 characters", () => {
+    assert.ok(
+      messagesFor({
+        url: "https://example.com",
+        shorthand: "s".repeat(31),
+      }).includes("shorthand must be less than 30 characters"),
+    );
+  });
+
+  test("rejects a missing url", () => {
+    assert.equal(formSchema.safeParse({}).success, false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.9.3",
-    "zod": "^3.22.3"
+    "zod": "^4.4.3"
   },
   "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       zod:
-        specifier: ^3.22.3
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@playwright/test':
         specifier: 1.62.1
@@ -2449,8 +2449,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3641,8 +3641,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 10.8.0(jiti@1.21.7)(supports-color@7.2.0)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4639,8 +4639,8 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

Upgrades `zod` 3.25.76 -> 4.4.3, and closes a coverage gap while doing it.

## Tests first

`lib/schemas.ts` had no tests, despite being the validation the create API depends on. Seven
were written **against zod 3** and confirmed passing there, pinning the current behaviour —
including the exact user-facing messages, which surface in the form:

- accepts a plain https url, and an optional shorthand
- rejects a non-url, a non-http scheme, a url over 2000 chars, a shorthand over 30 chars,
  and a missing url

Only then was zod upgraded. **All 15 unit tests pass unchanged on zod 4** with no edit to
`lib/schemas.ts` — so the upgrade preserves behaviour rather than merely compiling.

## Nothing needed changing

`z.string().url()` carries no deprecation annotation in 4.4.3 (checked the type definitions),
and `z.url()` exists alongside it, so the schema is left as-is for a minimal diff. Worth
revisiting if zod deprecates the method form later.

`ZodError.issues` — which `app/api/create/route.ts` maps into its error response — is still an
array of issue objects, verified directly rather than assumed.

## Testing

- `pnpm test:unit` — 15 passed (7 new)
- `pnpm test:e2e` — 9 passed
- `pnpm lint` — clean
- `pnpm build` — compiles
