### PR TITLE
ci: enforce formatting with oxfmt --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Lint
         run: pnpm lint
+      - name: Format check
+        run: pnpm format:check
       # Runs the migrations against throwaway SQLite files, so no database is needed.
       - name: Unit tests
         run: pnpm test:unit


### PR DESCRIPTION
## Summary

`pnpm format:check` was added in #27 but never wired into CI, so formatting drift could not fail a build — the same gap `--max-warnings=0` closed for linting.

Adds a `Format check` step to the `build` job, after `Lint`.

## Testing

- Passes on `main` as-is: *All matched files use the correct format* (41 files)
- Verified non-vacuous: adding a badly-formatted file makes it exit 1