### PR TITLE
chore: upgrade short-unique-id to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-hook-form": "^7.83.0",
-    "short-unique-id": "^4.4.4",
+    "short-unique-id": "^5.3.2",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^7.83.0
         version: 7.83.0(react@19.2.8)
       short-unique-id:
-        specifier: ^4.4.4
-        version: 4.4.4
+        specifier: ^5.3.2
+        version: 5.3.2
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -2262,8 +2262,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  short-unique-id@4.4.4:
-    resolution: {integrity: sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==}
+  short-unique-id@5.3.2:
+    resolution: {integrity: sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==}
     hasBin: true
 
   signal-exit@3.0.7:
@@ -4410,7 +4410,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  short-unique-id@4.4.4: {}
+  short-unique-id@5.3.2: {}
 
   signal-exit@3.0.7: {}
 


### PR DESCRIPTION
## Summary

`short-unique-id` 4.4.4 -> 5.3.2. No code change needed — `new ShortUniqueId({ length }).randomUUID()` in `lib/links.ts` works unchanged.

This one was worth doing first because it is the only remaining major with real test coverage behind it: `lib/links.test.mts` exercises shorthand generation, collision retry, and the bounded give-up path.

## Testing

- `pnpm test:unit` — 15 passed
- `pnpm test:e2e` — 9 passed
- `pnpm lint` / `pnpm format:check` — clean
- `pnpm build` — compiles

The unit tests inject a fake generator for the collision cases, so I also checked the real generator directly: lengths honoured (4, 4, 6), URL-safe characters only, distinct values.