### PR TITLE
chore: upgrade tailwind-merge and hookform resolvers

### DIFF
--- a/lib/resolver.test.mts
+++ b/lib/resolver.test.mts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { formSchema } from "./schemas.ts";
+
+/**
+ * `zodResolver` is the seam between zod and react-hook-form, and the only place
+ * the two majors meet. `UrlForm` sits behind authentication so the e2e suite
+ * cannot reach it; this covers the adapter directly instead.
+ */
+const resolve = zodResolver(formSchema);
+const options = { fields: {}, shouldUseNativeValidation: false } as never;
+
+describe("zodResolver", () => {
+  test("passes valid input through", async () => {
+    const result = await resolve({ url: "https://example.com" }, undefined, options);
+
+    assert.deepEqual(result.errors, {});
+    assert.deepEqual(result.values, { url: "https://example.com" });
+  });
+
+  test("surfaces the schema's message on the offending field", async () => {
+    const result = await resolve({ url: "ftp://example.com" }, undefined, options);
+
+    assert.deepEqual(result.values, {});
+    assert.equal(
+      (result.errors as Record<string, { message?: string }>).url?.message,
+      "URL must start with http:// or https://",
+    );
+  });
+
+  test("reports a missing url rather than throwing", async () => {
+    const result = await resolve({}, undefined, options);
+    assert.ok("url" in result.errors);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.6.4",
     "@clerk/themes": "^2.4.57",
-    "@hookform/resolvers": "^3.3.1",
+    "@hookform/resolvers": "^5.5.7",
     "@libsql/kysely-libsql": "^0.4.1",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.15",
@@ -38,7 +38,7 @@
     "react-dom": "19.2.8",
     "react-hook-form": "^7.83.0",
     "short-unique-id": "^4.4.4",
-    "tailwind-merge": "^1.14.0",
+    "tailwind-merge": "^3.6.0",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.4.57
         version: 2.4.57(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@hookform/resolvers':
-        specifier: ^3.3.1
-        version: 3.10.0(react-hook-form@7.83.0(react@19.2.8))
+        specifier: ^5.5.7
+        version: 5.5.7(react-hook-form@7.83.0(react@19.2.8))(zod@4.4.3)
       '@libsql/kysely-libsql':
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.29.4)
@@ -78,8 +78,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.4
       tailwind-merge:
-        specifier: ^1.14.0
-        version: 1.14.0
+        specifier: ^3.6.0
+        version: 3.6.0
       tailwindcss:
         specifier: 3.3.3
         version: 3.3.3
@@ -288,10 +288,83 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hookform/resolvers@3.10.0':
-    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+  '@hookform/resolvers@5.5.7':
+    resolution: {integrity: sha512-CyPCYV8/KlXfEXLWj8HHHhVsR/IZ6Ckm3b/a4fWtO/lRnRK1huqncb8LlAWrmpPRsse5glF5aVuDRMHEr3UGag==}
     peerDependencies:
-      react-hook-form: ^7.0.0
+      '@sinclair/typebox': '>=0.25.24'
+      '@standard-schema/spec': ^1.0.0
+      '@typeschema/main': '>=0.13.7'
+      '@vinejs/vine': ^2.0.0 || ^3.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^0.7.0
+      class-transformer: '>=0.4.0'
+      class-validator: '>=0.12.0'
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0
+      nope-validator: '>=0.12.0'
+      react-hook-form: ^7.55.0
+      superstruct: '>=0.12.0'
+      typanion: ^3.3.2
+      valibot: '>=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc'
+      vest: '>=3.0.0'
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@standard-schema/spec':
+        optional: true
+      '@typeschema/main':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1075,6 +1148,9 @@ packages:
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2273,8 +2349,8 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  tailwind-merge@1.14.0:
-    resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -2669,9 +2745,12 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hookform/resolvers@3.10.0(react-hook-form@7.83.0(react@19.2.8))':
+  '@hookform/resolvers@5.5.7(react-hook-form@7.83.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
+      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.83.0(react@19.2.8)
+    optionalDependencies:
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3212,6 +3291,8 @@ snapshots:
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4425,7 +4506,7 @@ snapshots:
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  tailwind-merge@1.14.0: {}
+  tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.3.3):
     dependencies:


### PR DESCRIPTION
## Summary

- `tailwind-merge` 1.14.0 -> 3.6.0 — one call site, `cn()` in `lib/utils.ts`
- `@hookform/resolvers` 3.10.0 -> 5.5.7 — one call site, `zodResolver` in `UrlForm`

Neither needed a code change.

## Closes a real coverage gap

`zodResolver` is the seam between zod 4 and resolvers 5 — the only place the two majors meet — and nothing covered it. `UrlForm` sits behind authentication, so the e2e suite cannot reach it.

`lib/resolver.test.mts` now tests the adapter directly: valid input passes through, an invalid scheme surfaces the schema's own message on the right field, and a missing url is reported rather than thrown.

Verified non-vacuous — changing the expected message makes it fail (17 pass / 1 fail), restoring it returns 18.

## Not covered

`tailwind-merge` only affects class-string merging, which no test exercises. The risk is visual rather than functional, and `cn()` is a single pass-through, so I did not add a test for it.

## Testing

- `pnpm test:unit` — 18 passed (3 new)
- `pnpm test:e2e` — 9 passed
- `pnpm lint` / `pnpm format:check` — clean
- `pnpm build` — compiles