### PR TITLE
docs: restructure readme

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,8 +1,15 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  // Listing a plugin only makes its rules available — oxlint activates just the
+  // `correctness` category, so anything below that is enabled explicitly below.
+  // Not implemented by oxlint, so not checked anywhere: the React Compiler-era
+  // rules (set-state-in-render, set-state-in-effect, immutability, purity, refs,
+  // static-components, use-memo). setState during render lints clean.
   "plugins": ["react", "jsx-a11y", "nextjs", "import", "typescript", "unicorn", "oxc"],
   "rules": {
+    // Automatic JSX runtime is in use, so React need not be in scope.
     "react/react-in-jsx-scope": "off",
+    // app/layout.tsx imports globals.css for its side effect.
     "import/no-unassigned-import": "off",
     "react/rules-of-hooks": "error",
     "react/exhaustive-deps": "warn",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You need a [Clerk](https://clerk.com/) application for auth and a
 | ------------------------------------------------------ | ------------------------------------------------------------------ |
 | `DATABASE_URL`                                         | `libsql://…turso.io?authToken=…`                                   |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`                    | public; the app cannot render a page without it                    |
-| `CLERK_SECRET_KEY`                                     | **instance admin credential** — see [Checks](#checks)              |
+| `CLERK_SECRET_KEY`                                     | can mint a session for any user — keep it out of CI                |
 | `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_URL`                   | `/sign-in`, `/sign-up`                                             |
 | `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_FALLBACK_REDIRECT_URL` | `/` — note the name: `AFTER_SIGN_IN_URL` etc. are silently ignored |
 
@@ -32,7 +32,7 @@ You need a [Clerk](https://clerk.com/) application for auth and a
 **Every route runs on the edge runtime.** That is the constraint behind most of the
 decisions here: on edge, `@libsql/client` resolves to its web build, which speaks HTTP to a
 libsql server and cannot open a local SQLite file. So there is no "just use a file locally"
-option — see [Tests](#tests).
+option — the e2e suite runs a libsql container instead.
 
 Auth is Clerk middleware, in `proxy.ts`:
 
@@ -86,44 +86,11 @@ pnpm lint          # oxlint
 pnpm format        # oxfmt, write
 pnpm format:check  # oxfmt, check only
 pnpm test:unit     # node --test
-pnpm test:e2e      # Playwright
+pnpm test:e2e      # Playwright — needs Docker running
 ```
 
 CI runs `lint`, `format:check`, `test:unit`, `test:e2e` and the build on every push and pull
 request.
-
-### Linting
-
-[oxlint](https://oxc.rs/docs/guide/usage/linter.html), configured in `.oxlintrc.json`, with
-`--max-warnings=0` so warnings fail rather than scroll past.
-
-Enabling a plugin only makes its rules _available_ — oxlint activates just its `correctness`
-category. Anything below that is switched on explicitly under `rules`; without that, a
-conditionally-called hook lints clean.
-
-**Not checked.** `rules-of-hooks` and `exhaustive-deps` are enforced, but the React
-Compiler-era rules are not — oxlint does not implement them. Calling `setState` during render
-or in an effect, mutating props, or reading a ref during render will all lint clean.
-
-### Tests
-
-`pnpm test:unit` covers migrations, link creation, the zod schema and the react-hook-form
-resolver. Plain Node, file-backed SQLite, no browser.
-
-`pnpm test:e2e` starts a throwaway [libsql-server](https://github.com/tursodatabase/libsql)
-container via testcontainers, migrates it and runs the app against it — so **Docker must be
-running**. Two groups:
-
-- **`tests/auth.spec.ts`** — that Clerk is _enforced_: `/` redirects to sign-in,
-  `POST /api/create` answers 401, the sign-in page renders. Needs **both** Clerk keys, since
-  `auth.protect` throws `MissingSecretKey` without the secret one.
-- **`tests/product.spec.ts`** — the shortener itself, needing **no Clerk configuration at
-  all**. Links are seeded straight into the database and fetched through `/[slug]`; Playwright
-  waits on `/api/health` so the server starts without a publishable key.
-
-`CLERK_SECRET_KEY` can mint a session for any user in the instance, so it is deliberately
-**not** in CI. The auth specs skip there and run locally. That is why CI reports
-`5 passed, 4 skipped`.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,119 +1,152 @@
-Basic URL-shortener, trying out the new App Router & RSC Next.JS along with some random other tools ([Kysely](https://kysely.dev/), [Turso](https://turso.tech/) etc.)
+A URL shortener, and a place to try out App Router / RSC Next.js with
+[Kysely](https://kysely.dev/), [Turso](https://turso.tech/) and [Clerk](https://clerk.com/).
 
-## Development
+Deployed at [l.kalski.xyz](https://l.kalski.xyz).
 
-You need to setup [Clerk](https://clerk.com/) for auth and [Turso](https://turso.tech/) for DB connection.
+## Getting started
+
+Toolchain versions are pinned in `mise.toml` ([mise](https://mise.jdx.dev)):
 
 ```shell
-cp .env.example .env.local
+mise install                # Node + pnpm
+cp .env.example .env.local  # then fill it in, see below
 pnpm install
 pnpm dev
 ```
 
-## Dependencies
+You need a [Clerk](https://clerk.com/) application for auth and a
+[Turso](https://turso.tech/) database.
 
-`@types/node` is pinned to the **24.x** line to match the Node version in `mise.toml`. Tooling
-will keep offering newer majors — they describe APIs that do not exist in Node 24, so code
-would type-check and then fail at runtime. Bump it only alongside the runtime.
+### Environment
+
+| Variable                                               | Notes                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------- |
+| `DATABASE_URL`                                         | `libsql://…turso.io?authToken=…`                                    |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`                    | public; the app cannot render a page without it                     |
+| `CLERK_SECRET_KEY`                                     | **instance admin credential** — see [Checks](#checks)               |
+| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_URL`                   | `/sign-in`, `/sign-up`                                              |
+| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_FALLBACK_REDIRECT_URL` | `/` — renamed in Clerk v5; the old `AFTER_SIGN_*` names are ignored |
+
+## Architecture
+
+**Every route runs on the edge runtime.** That is the constraint behind most of the
+decisions here: on edge, `@libsql/client` resolves to its web build, which speaks HTTP to a
+libsql server and cannot open a local SQLite file. So there is no "just use a file locally"
+option — see [Tests](#tests).
+
+Auth is Clerk middleware in `proxy.ts` (`middleware.ts` was renamed in Next 16):
+
+| Path                   | Behaviour                                                              |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `/`                    | **protected** — `auth.protect()` redirects to sign-in                  |
+| `/api/create`          | middleware runs; the handler checks `auth()` itself and answers 401    |
+| `/sign-in`, `/sign-up` | middleware runs so Clerk's handshake can complete                      |
+| `/[slug]`              | **public** — a route handler, outside the matcher, never touches Clerk |
+| `/api/health`          | **public** — liveness, no Clerk                                        |
+
+`clerkMiddleware()` protects nothing by default, unlike v4's `authMiddleware({})`. The
+protected set is listed explicitly; dropping it silently makes the home page public.
+
+`/[slug]` caches lookups with `unstable_cache`, but never trusts a cached miss — a link
+created after someone first tried the slug would otherwise keep 404ing for an hour.
 
 ## Database
 
 Schema changes are [Kysely migrations](https://kysely.dev/docs/migrations) in
-`db_migration/migrations`. They run in order and are recorded in a `kysely_migration`
-table, so re-running applies only what is pending.
+`db_migration/migrations`. They run in order and are recorded in a `kysely_migration` table,
+so re-running applies only what is pending.
 
 ```shell
-DATABASE_URL=<url> pnpm db:status    # read-only: what is applied, what is pending
+DATABASE_URL=<url> pnpm db:status    # read-only: applied vs pending
 DATABASE_URL=<url> pnpm db:migrate   # apply everything pending
 ```
 
+`pnpm kysely-generate` migrates a local `local.db` and regenerates `types/db.d.ts` from it.
+Run it after adding a migration so the generated types match.
+
 ### ⚠️ Migrations are never applied automatically
 
-Nothing runs them for you — not the Vercel build, not CI, not the app at startup.
-`next build` only builds. **A schema change reaches production only when a human runs
-`pnpm db:migrate` against the production database.**
+Nothing runs them for you — not the Vercel build, not CI, not the app at startup. **A schema
+change reaches production only when a human runs `pnpm db:migrate` against it.**
 
-That means a deploy can ship code expecting a column that does not exist yet. The order
-matters:
+So a deploy can ship code expecting a column that does not exist. Order matters:
 
-| Change                                 | Order                                                      |
-| -------------------------------------- | ---------------------------------------------------------- |
-| Additive (new table/column, new index) | migrate **first**, then deploy                             |
-| Destructive (drop/rename a column)     | deploy code that no longer uses it **first**, then migrate |
+| Change                             | Order                                                     |
+| ---------------------------------- | --------------------------------------------------------- |
+| Additive (new table/column/index)  | migrate **first**, then deploy                            |
+| Destructive (drop/rename a column) | deploy code that stopped using it **first**, then migrate |
 
-### Applying to production
+Run `db:status` before `db:migrate` — it connects and reports without changing anything,
+which also confirms you are pointed at the database you think you are.
 
-Get the Turso URL (the same `DATABASE_URL` the Vercel project uses), then:
-
-```shell
-DATABASE_URL='libsql://<db>.turso.io?authToken=<token>' pnpm db:status
-DATABASE_URL='libsql://<db>.turso.io?authToken=<token>' pnpm db:migrate
-```
-
-Always run `db:status` first — it connects and reports without changing anything, which
-also confirms you are pointed at the database you think you are.
-
-> The production database predates this migration setup and has no `kysely_migration`
-> table yet. `0001_initial` is written entirely with `ifNotExists`, so the first
-> production run records it as applied **without touching the existing table or data**.
-> It is a bookkeeping no-op, and it needs to happen before any later migration can run.
-
-### Local database and types
-
-`pnpm kysely-generate` migrates a local `local.db` and regenerates `types/db.d.ts` from
-it. Run it after adding a migration so the generated types match.
-
-Migration behaviour is covered by `pnpm test:unit`, which runs in CI against throwaway
-SQLite files — no database required.
-
-## Tests
+## Checks
 
 ```shell
 pnpm lint          # oxlint
-pnpm format        # oxfmt (write)
-pnpm format:check  # oxfmt (check only)
-pnpm test:unit  # migration + link-creation tests (node --test)
-pnpm test:e2e   # end-to-end (Playwright)
+pnpm format        # oxfmt, write
+pnpm format:check  # oxfmt, check only
+pnpm test:unit     # node --test
+pnpm test:e2e      # Playwright
 ```
 
-Linting is [oxlint](https://oxc.rs/docs/guide/usage/linter.html), configured in
-`.oxlintrc.json`. It runs with `--max-warnings=0`, so warnings fail rather than scroll past.
+CI runs `lint`, `format:check`, `test:unit`, `test:e2e` and the build on every push and pull
+request.
 
-Enabling a plugin only makes its rules _available_ — oxlint still activates just its
-`correctness` category. Rules that `eslint-config-next` enabled but oxlint ranks lower are
-switched on explicitly in `rules`; without that, a conditionally-called hook lints clean.
+### Linting
 
-**Known gap.** `eslint-plugin-react-hooks@7` ships React Compiler-era rules —
+[oxlint](https://oxc.rs/docs/guide/usage/linter.html), configured in `.oxlintrc.json`, with
+`--max-warnings=0` so warnings fail rather than scroll past.
+
+Enabling a plugin only makes its rules _available_ — oxlint activates just its `correctness`
+category. Anything below that is switched on explicitly under `rules`; without that, a
+conditionally-called hook lints clean.
+
+**Known gap.** `eslint-plugin-react-hooks` ships React Compiler-era rules —
 `set-state-in-render`, `set-state-in-effect`, `immutability`, `purity`, `refs`,
-`static-components`, `use-memo` — that oxlint does not implement. ESLint was kept briefly to
-cover them, then dropped in favour of a single linter. `rules-of-hooks` and `exhaustive-deps`
-are still enforced by oxlint; those seven are not, so calling `setState` during render lints
-clean.
+`static-components`, `use-memo` — that oxlint does not implement, and there is no ESLint pass
+here. `rules-of-hooks` and `exhaustive-deps` _are_ enforced; calling `setState` during render
+is not caught.
 
-The e2e suite starts a throwaway [libsql-server](https://github.com/tursodatabase/libsql)
-container via testcontainers, migrates it, and runs the app against it, so **Docker must be
-running**. A container is used rather than a SQLite file because every route sets
-`runtime = "edge"`, where `@libsql/client` is the web build and cannot open local files.
+### Tests
 
-There are two groups:
+`pnpm test:unit` covers migrations, link creation, the zod schema and the react-hook-form
+resolver. Plain Node, file-backed SQLite, no browser.
 
-- **`tests/auth.spec.ts`** — that Clerk is _enforced_: the home page redirects to sign-in,
-  `POST /api/create` answers 401, the sign-in page renders. No session is created.
-- **`tests/product.spec.ts`** — the shortener itself, with Clerk out of the picture. Links are
-  seeded straight into the database and fetched through `/[slug]`, which is a route handler
-  and so never renders the ClerkProvider layout.
+`pnpm test:e2e` starts a throwaway [libsql-server](https://github.com/tursodatabase/libsql)
+container via testcontainers, migrates it and runs the app against it — so **Docker must be
+running**. Two groups:
 
-The product specs need **no Clerk configuration at all** — Playwright waits on `/api/health`,
-a route handler outside the proxy matcher, so the server starts without a publishable key. Run
-them anywhere, including forked PRs. The auth specs skip when
-`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is absent, since pages render through `ClerkProvider` and
-cannot load without it. That key is public — it ships in the browser bundle.
+- **`tests/auth.spec.ts`** — that Clerk is _enforced_: `/` redirects to sign-in,
+  `POST /api/create` answers 401, the sign-in page renders. Needs **both** Clerk keys, since
+  `auth.protect` throws `MissingSecretKey` without the secret one.
+- **`tests/product.spec.ts`** — the shortener itself, needing **no Clerk configuration at
+  all**. Links are seeded straight into the database and fetched through `/[slug]`; Playwright
+  waits on `/api/health` so the server starts without a publishable key.
 
-The auth specs need **both** Clerk keys — `clerkMiddleware` and `auth.protect` throw
-`MissingSecretKey` without `CLERK_SECRET_KEY`. That key is an instance admin credential which
-can mint a session for any user, so it is deliberately kept out of CI; the auth specs skip
-there and run locally, where `.env.local` supplies both.
+`CLERK_SECRET_KEY` can mint a session for any user in the instance, so it is deliberately
+**not** in CI. The auth specs skip there and run locally. That is why CI reports
+`5 passed, 4 skipped`.
 
-Slugs are suffixed with a per-run id: `/[slug]` caches lookups with `unstable_cache`, that
-cache lives in `.next/cache` and survives between runs, so a slug requested in an earlier run
-would keep serving its cached 404.
+## Deployment
+
+Vercel, on push. `next build` only builds — it does not migrate.
+
+### ⚠️ `ENABLE_EXPERIMENTAL_COREPACK=1` is required
+
+Set on Production and Preview. **Do not remove it.**
+
+Vercel [supports pnpm 6–10 natively](https://vercel.com/docs/package-managers) and infers the
+version from `lockfileVersion`, which pnpm 11 leaves at `9.0`. Without corepack, Vercel picks
+pnpm 9, which rejects a `pnpm-workspace.yaml` that has no `packages:` field — and this one
+intentionally has only `allowBuilds` and `overrides`. The build fails with
+`ERROR packages field missing or empty`. With the variable set, Vercel reads `packageManager`
+from `package.json` instead.
+
+## Gotchas
+
+- **`@types/node` is pinned to the 24.x line** to match the Node version in `mise.toml`.
+  Tooling keeps offering newer majors; they describe APIs that do not exist in Node 24, so
+  code would type-check and then fail at runtime. Bump it only alongside the runtime.
+- **`pnpm-workspace.yaml` carries real configuration** — `allowBuilds` (pnpm 11 blocks
+  dependency build scripts by default) and an `overrides` entry deduping `postcss`, which Next
+  pins to a version carrying advisories.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ You need a [Clerk](https://clerk.com/) application for auth and a
 
 ### Environment
 
-| Variable                                               | Notes                                                               |
-| ------------------------------------------------------ | ------------------------------------------------------------------- |
-| `DATABASE_URL`                                         | `libsql://…turso.io?authToken=…`                                    |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`                    | public; the app cannot render a page without it                     |
-| `CLERK_SECRET_KEY`                                     | **instance admin credential** — see [Checks](#checks)               |
-| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_URL`                   | `/sign-in`, `/sign-up`                                              |
-| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_FALLBACK_REDIRECT_URL` | `/` — renamed in Clerk v5; the old `AFTER_SIGN_*` names are ignored |
+| Variable                                               | Notes                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| `DATABASE_URL`                                         | `libsql://…turso.io?authToken=…`                                   |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`                    | public; the app cannot render a page without it                    |
+| `CLERK_SECRET_KEY`                                     | **instance admin credential** — see [Checks](#checks)              |
+| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_URL`                   | `/sign-in`, `/sign-up`                                             |
+| `NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_FALLBACK_REDIRECT_URL` | `/` — note the name: `AFTER_SIGN_IN_URL` etc. are silently ignored |
 
 ## Architecture
 
@@ -34,7 +34,7 @@ decisions here: on edge, `@libsql/client` resolves to its web build, which speak
 libsql server and cannot open a local SQLite file. So there is no "just use a file locally"
 option — see [Tests](#tests).
 
-Auth is Clerk middleware in `proxy.ts` (`middleware.ts` was renamed in Next 16):
+Auth is Clerk middleware, in `proxy.ts`:
 
 | Path                   | Behaviour                                                              |
 | ---------------------- | ---------------------------------------------------------------------- |
@@ -44,8 +44,8 @@ Auth is Clerk middleware in `proxy.ts` (`middleware.ts` was renamed in Next 16):
 | `/[slug]`              | **public** — a route handler, outside the matcher, never touches Clerk |
 | `/api/health`          | **public** — liveness, no Clerk                                        |
 
-`clerkMiddleware()` protects nothing by default, unlike v4's `authMiddleware({})`. The
-protected set is listed explicitly; dropping it silently makes the home page public.
+`clerkMiddleware()` protects nothing on its own — the protected set above is what does it.
+Removing that call makes `/` public with no error anywhere.
 
 `/[slug]` caches lookups with `unstable_cache`, but never trusts a cached miss — a link
 created after someone first tried the slug would otherwise keep 404ing for an hour.
@@ -101,11 +101,9 @@ Enabling a plugin only makes its rules _available_ — oxlint activates just its
 category. Anything below that is switched on explicitly under `rules`; without that, a
 conditionally-called hook lints clean.
 
-**Known gap.** `eslint-plugin-react-hooks` ships React Compiler-era rules —
-`set-state-in-render`, `set-state-in-effect`, `immutability`, `purity`, `refs`,
-`static-components`, `use-memo` — that oxlint does not implement, and there is no ESLint pass
-here. `rules-of-hooks` and `exhaustive-deps` _are_ enforced; calling `setState` during render
-is not caught.
+**Not checked.** `rules-of-hooks` and `exhaustive-deps` are enforced, but the React
+Compiler-era rules are not — oxlint does not implement them. Calling `setState` during render
+or in an effect, mutating props, or reading a ref during render will all lint clean.
 
 ### Tests
 


### PR DESCRIPTION
## Summary

The README had grown by accretion over this week's changes — a one-note "Dependencies" section
wedged between Getting Started and Database, lint and formatting docs buried under a "Tests"
heading, and a lot of prose explaining *why a change was made* rather than what a reader needs.

Restructured around what someone actually needs, in the order they need it:

```
Getting started → Environment → Architecture → Database → Checks → Deployment → Gotchas
```

## Two things were missing entirely

**`ENABLE_EXPERIMENTAL_COREPACK=1` was documented nowhere** — only in #21's description. It is
set on Production and Preview, and **removing it breaks deploys**: Vercel would fall back to
pnpm 9, which rejects a `pnpm-workspace.yaml` with no `packages:` field, failing with
`ERROR packages field missing or empty`. That is now its own section.

**There was no Deployment section at all** — the original `## Deploy on Vercel` was
`create-next-app` boilerplate and I deleted it earlier while rewriting. The repo has real
deploy requirements now, so it is back with actual content.

## Added

- **Architecture** — the edge-runtime constraint that explains the libsql/container decisions,
  and a table of which paths are protected, public, or middleware-only. The
  `clerkMiddleware()`-protects-nothing trap is stated, since that is what caused the auth
  regression.
- **Environment** — a table of the variables, including that the publishable key is public
  while the secret key is an instance admin credential.
- The `unstable_cache` never-trust-a-miss behaviour, which is otherwise only visible as a
  comment in the route.

## Trimmed

Migration history — "ESLint was kept briefly, then dropped" and similar. That belongs in PR
descriptions, not a README. The *consequence* is kept: the oxlint known-gap list, because it
tells you what is not caught.

## Verified, not remembered

Every factual claim was checked against the code rather than written from memory:

- all seven routes really do declare `runtime = "edge"`
- `createRouteMatcher(["/"])` is the protected set
- `/api/health` is outside the proxy matcher
- `pnpm-workspace.yaml` has no `packages:` field
- CI really runs `lint`, `format:check`, `test:unit`, `test:e2e` and the build

That last one caught an error of mine: I had written "CI runs all five", but `pnpm format` is
the write variant and CI cannot run it. Corrected.

`ENABLE_EXPERIMENTAL_COREPACK` was confirmed still present on both environments via
`vercel env ls` before documenting it as required.
